### PR TITLE
Fix crash when resource pointer is NULL.

### DIFF
--- a/libdroplet/src/backend/s3/backend/head.c
+++ b/libdroplet/src/backend/s3/backend/head.c
@@ -58,7 +58,7 @@ dpl_s3_head(dpl_ctx_t *ctx,
    * an empty object is used to create directories, instead of simply using the
    * delimiters in the paths)
    */
-  if (resource[strlen(resource)-1] != '/' || ctx->empty_folder_emulation)
+  if ((resource && resource[strlen(resource)-1] != '/') || ctx->empty_folder_emulation)
     {
       ret2 = dpl_s3_head_raw(ctx, bucket, resource, subresource, NULL,
                              object_type, condition, &headers_reply, locationp);

--- a/libdroplet/src/backend/s3/backend/head.c
+++ b/libdroplet/src/backend/s3/backend/head.c
@@ -58,7 +58,8 @@ dpl_s3_head(dpl_ctx_t *ctx,
    * an empty object is used to create directories, instead of simply using the
    * delimiters in the paths)
    */
-  if ((resource && resource[strlen(resource)-1] != '/') || ctx->empty_folder_emulation)
+  int rl = 0;
+  if ((resource && (rl = strlen(resource)) > 0 && resource[rl-1] != '/') || ctx->empty_folder_emulation)
     {
       ret2 = dpl_s3_head_raw(ctx, bucket, resource, subresource, NULL,
                              object_type, condition, &headers_reply, locationp);


### PR DESCRIPTION
This bug fix is present in mvw's fork but not here.