### PR TITLE
fix S3 http header and non-English locale problem

### DIFF
--- a/droplet-3.0.pc.in
+++ b/droplet-3.0.pc.in
@@ -8,4 +8,4 @@ Description: Scality Droplet Library
 Version: @VERSION@
 Requires: libcrypto libxml-2.0 @JSON_PKG_NAME@
 Libs: -L${libdir} -ldroplet
-Cflags: -I${includedir}/droplet-3.0
+Cflags:

--- a/libdroplet.obs.spec
+++ b/libdroplet.obs.spec
@@ -1,0 +1,79 @@
+%define name libdroplet
+%define release 1
+%define version 1
+
+# do not optimize during compile for debugging
+%define noopt 1
+
+
+Summary: Scality Droplet library
+License: BSD
+Name: %{name}
+Version: 3.0.git.1390558635
+Release: 0%{release}
+Source: %{name}-%{version}.tar.bz2
+Group: Development/Tools
+BuildRequires: libxml2-devel, libjson-devel
+BuildRequires: automake, autoconf, libtool, pkg-config, check-devel, openssl-devel, bison, attr-devel
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+
+BuildRequires: -post-build-checks
+
+%description
+Library to help the transition to object based cloud storage by providing a
+structured API to simplify application developers job and address key user
+concerns.
+
+%package devel
+Group: Development/Libraries
+Summary: Developer tools for the Scality Droplet library
+Requires: libdroplet = %{version}-%{release}
+Requires: libxml2-devel
+
+%description devel
+Header files needed to develop programs that link against the Droplet library.
+
+%prep
+%setup -q
+#%patch1 -p1
+
+aclocal -I m4
+autoreconf -i -f
+
+%build
+
+%if %{noopt}
+export CFLAGS="-g"
+export CXXFLAGS="-g"
+export GCJFLAGS="-g"
+%endif
+
+%configure
+
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=$RPM_BUILD_ROOT
+/sbin/ldconfig -N -n %{buildroot}%{_libdir}
+
+%clean
+rm -rf %{buildroot}
+
+%post -p /sbin/ldconfig
+
+%postun -p /sbin/ldconfig
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/libdroplet.so.*
+
+%files devel
+%defattr(-,root,root,-)
+%{_includedir}/droplet.h
+%{_includedir}/dropletp.h
+%{_includedir}/droplet
+%{_libdir}/libdroplet.so
+%{_libdir}/libdroplet.a
+%{_libdir}/libdroplet.la
+%{_libdir}/pkgconfig/droplet-3.0.pc

--- a/libdroplet/Makefile.am
+++ b/libdroplet/Makefile.am
@@ -85,12 +85,12 @@ libdroplet_la_SOURCES = \
 	src/backend/posix/reqbuilder.c \
 	src/backend/posix/replyparser.c
 
-libdropletincludedir = $(includedir)/droplet-3.0/
+libdropletincludedir = $(includedir)
 libdropletinclude_HEADERS = \
 	include/droplet.h \
 	include/dropletp.h
 
-libdropletdropletincludedir = $(includedir)/droplet-3.0/droplet
+libdropletdropletincludedir = $(includedir)/droplet
 libdropletdropletinclude_HEADERS = \
 	include/droplet/conn.h \
 	include/droplet/converters.h \
@@ -116,14 +116,14 @@ libdropletdropletinclude_HEADERS = \
 	include/droplet/queue.h \
 	include/droplet/json_adapter.h
 
-libdropletdroplets3includedir = $(includedir)/droplet-3.0/droplet/s3
+libdropletdroplets3includedir = $(includedir)/droplet/s3
 libdropletdroplets3include_HEADERS = \
 	include/droplet/s3/backend.h \
 	include/droplet/s3/replyparser.h \
 	include/droplet/s3/reqbuilder.h \
 	include/droplet/s3/s3.h
 
-libdropletdropletcdmiincludedir = $(includedir)/droplet-3.0/droplet/cdmi
+libdropletdropletcdmiincludedir = $(includedir)/droplet/cdmi
 libdropletdropletcdmiinclude_HEADERS = \
 	include/droplet/cdmi/backend.h \
 	include/droplet/cdmi/replyparser.h \
@@ -132,14 +132,14 @@ libdropletdropletcdmiinclude_HEADERS = \
 	include/droplet/cdmi/crcmodel.h \
 	include/droplet/cdmi/cdmi.h
 
-libdropletdropletswiftincludedir = $(includedir)/droplet-3.0/droplet/swift
+libdropletdropletswiftincludedir = $(includedir)/droplet/swift
 libdropletdropletswiftinclude_HEADERS = \
 	include/droplet/swift/backend.h \
 	include/droplet/swift/replyparser.h \
 	include/droplet/swift/reqbuilder.h \
 	include/droplet/swift/swift.h
 
-libdropletdropletsrwsincludedir = $(includedir)/droplet-3.0/droplet/srws
+libdropletdropletsrwsincludedir = $(includedir)/droplet/srws
 libdropletdropletsrwsinclude_HEADERS = \
 	include/droplet/srws/backend.h \
 	include/droplet/srws/replyparser.h \
@@ -147,7 +147,7 @@ libdropletdropletsrwsinclude_HEADERS = \
 	include/droplet/srws/srws.h \
 	include/droplet/srws/key.h
 
-libdropletdropletsproxydincludedir = $(includedir)/droplet-3.0/droplet/sproxyd
+libdropletdropletsproxydincludedir = $(includedir)/droplet/sproxyd
 libdropletdropletsproxydinclude_HEADERS = \
 	include/droplet/sproxyd/backend.h \
 	include/droplet/sproxyd/replyparser.h \
@@ -155,18 +155,18 @@ libdropletdropletsproxydinclude_HEADERS = \
 	include/droplet/sproxyd/sproxyd.h \
 	include/droplet/sproxyd/key.h
 
-libdropletdropletposixincludedir = $(includedir)/droplet-3.0/droplet/posix
+libdropletdropletposixincludedir = $(includedir)/droplet/posix
 libdropletdropletposixinclude_HEADERS = \
 	include/droplet/posix/backend.h \
 	include/droplet/posix/reqbuilder.h \
 	include/droplet/posix/replyparser.h \
 	include/droplet/posix/posix.h
 
-libdropletdropletuksincludedir = $(includedir)/droplet-3.0/droplet/uks
+libdropletdropletuksincludedir = $(includedir)/droplet/uks
 libdropletdropletuksinclude_HEADERS = \
 	include/droplet/uks/uks.h
 
-libdropletdropletscalincludedir = $(includedir)/droplet-3.0/droplet/scal
+libdropletdropletscalincludedir = $(includedir)/droplet/scal
 libdropletdropletscalinclude_HEADERS = \
 	include/droplet/scal/gc.h
 

--- a/libdroplet/include/droplet.h
+++ b/libdroplet/include/droplet.h
@@ -323,7 +323,11 @@ typedef enum
 
 /**/
 
+#ifndef __cplusplus
 typedef enum
+#else
+enum
+#endif
   {
     DPL_SYSMD_MASK_CANNED_ACL    = (1u<<0),
     DPL_SYSMD_MASK_STORAGE_CLASS = (1u<<1),
@@ -342,7 +346,12 @@ typedef enum
     DPL_SYSMD_MASK_ENTERPRISE_NUMBER  = (1u<<15),
     DPL_SYSMD_MASK_PATH          = (1u<<16),
     DPL_SYSMD_MASK_VERSION       = (1u<<17),
+#ifndef __cplusplus
   } dpl_sysmd_mask_t;
+#else
+  };
+typedef unsigned int dpl_sysmd_mask_t;
+#endif
 
 typedef struct
 {

--- a/libdroplet/include/droplet.h
+++ b/libdroplet/include/droplet.h
@@ -513,31 +513,40 @@ struct dpl_backend_s;
 typedef struct dpl_ctx
 {
   /*
-   * profile
+   * Profile
    */
-  int n_conn_buckets;         /*!< number of buckets         */
-  int n_conn_max;             /*!< max connexions            */
-  int n_conn_max_hits;        /*!< before auto-close         */
-  int conn_idle_time;         /*!< auto-close after (sec)    */
-  int conn_timeout;           /*!< connection timeout (sec)  */
-  int read_timeout;           /*!< read timeout (sec)        */
-  int write_timeout;          /*!< write timeout (sec)       */
-  int use_https;
-  dpl_addrlist_t *addrlist;   /*!< list of addresses to contact */
-  int cur_host;               /*!< current host beeing used in addrlist */
-  int blacklist_expiretime;   /*!< expiration time of blacklisting */
-  char *base_path;            /*!< or RootURI */
+  int use_https:1;
+  int encode_slashes:1;         /*!< Client wants slashes encoded */
+  int empty_folder_emulation:1; /*!< Folders are represented as empty objects (otherwise, they're purely virtual) */
+  int keep_alive:1;             /*!< Client supports keep-alive */
+  int url_encoding:1;           /*!< Some servers does not handle url encoding */
+  int preserve_root_path:1;     /*!< Preserve "/" for root path access in HTTP requests */
+  int trace_buffers:1;
+  int trace_binary:1;           /*!< Default is trace ascii */
+  int ssl_comp:1;               /*!< SSL compression support (default to false) */
+  int cert_verif:1;             /*!< SSL certificate verification (default to true) */
+  int max_redirects;            /*!< Maximum number of redirects */
+  int n_conn_buckets;           /*!< Number of buckets         */
+  int n_conn_max;               /*!< Max connexions            */
+  int n_conn_max_hits;          /*!< Before auto-close         */
+  int conn_idle_time;           /*!< Auto-close after (sec)    */
+  int conn_timeout;             /*!< Connection timeout (sec)  */
+  int read_timeout;             /*!< Read timeout (sec)        */
+  int write_timeout;            /*!< Write timeout (sec)       */
+  dpl_addrlist_t *addrlist;     /*!< List of addresses to contact */
+  int cur_host;                 /*!< Current host beeing used in addrlist */
+  int blacklist_expiretime;     /*!< Expiration time of blacklisting */
+  char *base_path;              /*!< or RootURI */
   char *access_key;
   char *secret_key;
   unsigned char aws_auth_sign_version; /*!< S3 Auth signature version */
-  char aws_region[32];        /*!< AWS Region */
+  char aws_region[32];          /*!< AWS Region */
   /* SSL */
-  char *ssl_cert_file;        /*!< SSL certificate of the client*/
-  char *ssl_key_file;         /*!< SSL private key of the client*/
-  char *ssl_password;         /*!< password for the SSL private key*/
-  char *ssl_ca_list;          /*!< SSL certificate authority (CA) list*/
-  char *ssl_crl_list;          /*!< SSL certificate revocation list (CRL) list*/
-  int cert_verif;             /*!< SSL certificate verification (default to true) */
+  char *ssl_cert_file;          /*!< SSL certificate of the client*/
+  char *ssl_key_file;           /*!< SSL private key of the client*/
+  char *ssl_password;           /*!< password for the SSL private key*/
+  char *ssl_ca_list;            /*!< SSL certificate authority (CA) list*/
+  char *ssl_crl_list;           /*!< SSL certificate revocation list (CRL) list*/
 /*!< SSL method among SSLv3,TLSv1,TLSv1.1,TLSv1.2 and SSLv23 */
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
   const SSL_METHOD *ssl_method;
@@ -545,21 +554,13 @@ typedef struct dpl_ctx
   SSL_METHOD *ssl_method;
 #endif
   char *ssl_cipher_list;
-  int ssl_comp;               /*!< SSL compression support (default to false) */
   /* log */
   unsigned int trace_level;
-  int trace_buffers;
-  int trace_binary;          /*!< default is trace ascii */
-  char *pricing;             /*!< might be NULL */
+  unsigned int default_behavior_flags;
+  char *pricing;                /*!< might be NULL */
   unsigned int read_buf_size;
   char *encrypt_key;
-  int encode_slashes;        /*!< client wants slashes encoded */
-  int empty_folder_emulation;/*!< folders are represented as empty objects (otherwise, they're purely virtual) */
-  int keep_alive;            /*!< client supports keep-alive */
-  int url_encoding;          /*!< some servers does not handle url encoding */
-  int max_redirects;         /*!< maximum number of redirects */
-  int preserve_root_path;    /*!< Preserve "/" for root path access in HTTP requests */
-  uint32_t enterprise_number; /*!< for generating native IDs */
+  uint32_t enterprise_number;   /*!< for generating native IDs */
   struct dpl_backend_s *backend;
 
   /*
@@ -644,7 +645,7 @@ typedef struct
   char *host;
   char *port;
   dpl_behavior_flag_t behavior_flags;
-  
+
   dpl_method_t method;
   char *bucket;
   char *resource;

--- a/libdroplet/include/droplet.h
+++ b/libdroplet/include/droplet.h
@@ -547,6 +547,8 @@ typedef struct dpl_ctx
   char *ssl_password;           /*!< password for the SSL private key*/
   char *ssl_ca_list;            /*!< SSL certificate authority (CA) list*/
   char *ssl_crl_list;           /*!< SSL certificate revocation list (CRL) list*/
+  char *proxy_server;
+  char *proxy_port;
 /*!< SSL method among SSLv3,TLSv1,TLSv1.1,TLSv1.2 and SSLv23 */
 #if OPENSSL_VERSION_NUMBER >= 0x10000000L
   const SSL_METHOD *ssl_method;

--- a/libdroplet/include/droplet/backend.h
+++ b/libdroplet/include/droplet/backend.h
@@ -54,7 +54,7 @@
 #define DCL_BACKEND_DELETE_FN(fn)               DCL_BACKEND_FN(fn, const char *, const char *, const char *, const dpl_option_t *, dpl_ftype_t, const dpl_condition_t *, char **)
 #define DCL_BACKEND_DELETE_ALL_FN(fn)           DCL_BACKEND_FN(fn, const char *, dpl_locators_t *, const dpl_option_t *, const dpl_condition_t *, dpl_vec_t **)
 #define DCL_BACKEND_DELETE_ALL_ID_FN(fn)        DCL_BACKEND_FN(fn, const char *, const char *, dpl_locators_t *, const dpl_option_t *, const dpl_condition_t *, dpl_vec_t **)
-#define DCL_BACKEND_GENURL_FN(fn)               DCL_BACKEND_FN(fn, const char *, const char *, const char *, const dpl_option_t *, time_t, char *, unsigned int, unsigned int *, char **)
+#define DCL_BACKEND_GENURL_FN(fn)               DCL_BACKEND_FN(fn, const char *, const char *, const char *, const dpl_option_t *, time_t, char *, size_t, unsigned int *, char **)
 #define DCL_BACKEND_COPY_FN(fn)                 DCL_BACKEND_FN(fn, const char *, const char *, const char *, const char *, const char *, const char *, const dpl_option_t *, dpl_ftype_t, dpl_copy_directive_t, const dpl_dict_t *, const dpl_sysmd_t *, const dpl_condition_t *, char **)
 #define DCL_BACKEND_GET_ID_SCHEME_FN(fn)        DCL_BACKEND_FN(fn, dpl_id_scheme_t **)
 

--- a/libdroplet/include/droplet/httprequest.h
+++ b/libdroplet/include/droplet/httprequest.h
@@ -41,5 +41,5 @@ dpl_status_t dpl_add_range_to_headers(const dpl_range_t *range, dpl_dict_t *head
 dpl_status_t dpl_add_content_range_to_headers(const dpl_range_t *range, dpl_dict_t *headers);
 dpl_status_t dpl_add_condition_to_headers(const dpl_condition_t *condition, dpl_dict_t *headers);
 dpl_status_t dpl_add_basic_authorization_to_headers(const dpl_req_t *req, dpl_dict_t *headers);
-dpl_status_t dpl_req_gen_http_request(dpl_ctx_t *ctx, dpl_req_t *req, const dpl_dict_t *headers, const dpl_dict_t *query_params, char *buf, int len, unsigned int *lenp);
+dpl_status_t dpl_req_gen_http_request(dpl_ctx_t *ctx, dpl_req_t *req, const dpl_dict_t *headers, const dpl_dict_t *query_params, char *buf, size_t len, unsigned int *lenp);
 #endif

--- a/libdroplet/include/droplet/s3/reqbuilder.h
+++ b/libdroplet/include/droplet/s3/reqbuilder.h
@@ -42,7 +42,7 @@ typedef enum
 /* PROTO reqbuilder.c */
 /* src/reqbuilder.c */
 dpl_status_t dpl_s3_req_build(const dpl_req_t *req, dpl_s3_req_mask_t req_mask, dpl_dict_t **headersp);
-dpl_status_t dpl_s3_req_gen_url(const dpl_req_t *req, dpl_dict_t *headers, char *buf, int len, unsigned int *lenp);
+dpl_status_t dpl_s3_req_gen_url(const dpl_req_t *req, dpl_dict_t *headers, char *buf, size_t len, unsigned int *lenp);
 dpl_status_t dpl_s3_add_authorization_to_headers(const dpl_req_t *, dpl_dict_t *,
                                                  const dpl_dict_t *, struct tm *);
 

--- a/libdroplet/include/droplet/utils.h
+++ b/libdroplet/include/droplet/utils.h
@@ -208,15 +208,6 @@ int dpl_base64_init(void);
     *p = (Char);p++;len--;                                      \
   } while (0)
 
-#define DPL_APPEND_BUF(Buf, Len)                                \
-  do {                                                          \
-    if (len < (Len))                                            \
-      return DPL_FAILURE;                                       \
-    memcpy(p, (Buf), (Len)); p += (Len); len -= (Len);          \
-  } while (0)
-
-#define DPL_APPEND_STR(Str) DPL_APPEND_BUF((Str), strlen(Str))
-
 /**/
 
 #define DPL_TRACE(ctx, level, format, ...) do {if (ctx->trace_level & level) dpl_trace(ctx, level, __FILE__, __func__, __LINE__, format, ##__VA_ARGS__  );} while (0)
@@ -263,6 +254,7 @@ dpl_status_t dpl_log(dpl_ctx_t *ctx, dpl_log_level_t level, const char *file,
 void dpl_ssl_perror(dpl_ctx_t *ctx, const char *file, const char *func,
 		    int line, const char *str);
 dpl_status_t dpl_get_xattrs(char *path, dpl_dict_t *dict, char *prefix, int do_64encode);
+dpl_status_t dpl_append_str(const char *str_to_add, char **buff, size_t *size_buff);
 
 #define XATTRS_ENCODE_BASE64 1
 #define XATTRS_NO_ENCODING 0

--- a/libdroplet/include/droplet/utils.h
+++ b/libdroplet/include/droplet/utils.h
@@ -255,6 +255,7 @@ void dpl_ssl_perror(dpl_ctx_t *ctx, const char *file, const char *func,
 		    int line, const char *str);
 dpl_status_t dpl_get_xattrs(char *path, dpl_dict_t *dict, char *prefix, int do_64encode);
 dpl_status_t dpl_append_str(const char *str_to_add, char **buff, size_t *size_buff);
+size_t dpl_strftime_c(char *str, size_t maxsize, const char *format,  const struct tm *timeptr);
 
 #define XATTRS_ENCODE_BASE64 1
 #define XATTRS_NO_ENCODING 0

--- a/libdroplet/src/backend/s3/backend/genurl.c
+++ b/libdroplet/src/backend/s3/backend/genurl.c
@@ -43,7 +43,7 @@ dpl_s3_genurl(dpl_ctx_t *ctx,
               const dpl_option_t *option,
               time_t expires,
               char *buf,
-              unsigned int len,
+              size_t len,
               unsigned int *lenp,
               char **locationp)
 {

--- a/libdroplet/src/backend/s3/backend/head.c
+++ b/libdroplet/src/backend/s3/backend/head.c
@@ -58,7 +58,7 @@ dpl_s3_head(dpl_ctx_t *ctx,
    * an empty object is used to create directories, instead of simply using the
    * delimiters in the paths)
    */
-  if (resource[strlen(resource)-1] != '/' || ctx->empty_folder_emulation)
+  if ((resource && resource[strlen(resource)-1] != '/') || ctx->empty_folder_emulation)
     {
       ret2 = dpl_s3_head_raw(ctx, bucket, resource, subresource, NULL,
                              object_type, condition, &headers_reply, locationp);

--- a/libdroplet/src/backend/s3/backend/head.c
+++ b/libdroplet/src/backend/s3/backend/head.c
@@ -58,7 +58,8 @@ dpl_s3_head(dpl_ctx_t *ctx,
    * an empty object is used to create directories, instead of simply using the
    * delimiters in the paths)
    */
-  if ((resource && resource[strlen(resource)-1] != '/') || ctx->empty_folder_emulation)
+  int rl = 0;
+  if ((resource && (rl = strlen(resource)) > 0 && resource[rl-1] != '/') || ctx->empty_folder_emulation)
     {
       ret2 = dpl_s3_head_raw(ctx, bucket, resource, subresource, NULL,
                              object_type, condition, &headers_reply, locationp);

--- a/libdroplet/src/backend/s3/reqbuilder.c
+++ b/libdroplet/src/backend/s3/reqbuilder.c
@@ -592,10 +592,10 @@ dpl_s3_req_gen_url(const dpl_req_t *req,
 
   p = buf;
 
-  if (req->ctx->use_https)
-    DPL_APPEND_STR("https");
-  else
-    DPL_APPEND_STR("http");
+  DPL_APPEND_STR("http");
+  if (req->ctx->use_https) {
+    DPL_APPEND_STR("s");
+  }
   DPL_APPEND_STR("://");
   
   DPL_APPEND_STR(req->host);

--- a/libdroplet/src/backend/s3/reqbuilder.c
+++ b/libdroplet/src/backend/s3/reqbuilder.c
@@ -214,7 +214,7 @@ add_source_to_headers(const dpl_req_t *req,
 {
   int ret, ret2;
   char buf[1024];
-  u_int len = sizeof (buf);
+  size_t len = sizeof (buf);
   char *p;
   char src_resource_ue[DPL_URL_LENGTH(strlen(req->src_resource)) + 1];
 
@@ -232,15 +232,17 @@ add_source_to_headers(const dpl_req_t *req,
 
   p = buf;
 
-  DPL_APPEND_STR("/");
-  DPL_APPEND_STR(req->src_bucket);
-  DPL_APPEND_STR(src_resource_ue);
+  if (dpl_append_str("/", &p, &len) != DPL_SUCCESS
+    || dpl_append_str(req->src_bucket, &p, &len) != DPL_SUCCESS
+    || dpl_append_str(src_resource_ue, &p, &len) != DPL_SUCCESS)
+       return DPL_FAILURE;
 
   //subresource and query params
   if (NULL != req->src_subresource)
     {
-      DPL_APPEND_STR("?");
-      DPL_APPEND_STR(req->src_subresource);
+      if (dpl_append_str("?", &p, &len) != DPL_SUCCESS
+        || dpl_append_str(req->src_subresource, &p, &len) != DPL_SUCCESS)
+         return DPL_FAILURE;
     }
 
   DPL_APPEND_CHAR(0);
@@ -569,7 +571,7 @@ dpl_s3_req_build(const dpl_req_t *req,
 dpl_status_t
 dpl_s3_req_gen_url(const dpl_req_t *req,
                    dpl_dict_t *headers,
-                   char *buf, int len,
+                   char *buf, size_t len,
                    unsigned int *lenp)
 {
   int           bucket;
@@ -592,21 +594,26 @@ dpl_s3_req_gen_url(const dpl_req_t *req,
 
   p = buf;
 
-  DPL_APPEND_STR("http");
+  if (dpl_append_str("http", &p, &len) != DPL_SUCCESS)
+    return DPL_FAILURE;
+
   if (req->ctx->use_https) {
-    DPL_APPEND_STR("s");
+    if (dpl_append_str("s", &p, &len) != DPL_SUCCESS)
+       return DPL_FAILURE;
   }
-  DPL_APPEND_STR("://");
-  
-  DPL_APPEND_STR(req->host);
+
+  if (dpl_append_str("://", &p, &len) != DPL_SUCCESS
+    || dpl_append_str(req->host, &p, &len) != DPL_SUCCESS)
+      return DPL_FAILURE;
 
   if (( req->ctx->use_https && strcmp(req->port, "443")) ||
       (!req->ctx->use_https && strcmp(req->port, "80"))) {
-    DPL_APPEND_STR(":");
-    DPL_APPEND_STR(req->port);
+    if (dpl_append_str(":", &p, &len) != DPL_SUCCESS
+      || dpl_append_str(req->port, &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
   }
-
-  DPL_APPEND_STR(resource_ue);
+  if (dpl_append_str(resource_ue, &p, &len) != DPL_SUCCESS)
+    return DPL_FAILURE;
 
   if (req->ctx->aws_auth_sign_version == 2)
     ret = dpl_s3_get_authorization_v2_params(req, query_params, NULL);
@@ -622,14 +629,17 @@ dpl_s3_req_gen_url(const dpl_req_t *req,
     while (param != NULL) {
       if (ret == DPL_SUCCESS) {
         if (is_first_param) {
-          DPL_APPEND_STR("?");
+          if (dpl_append_str("?", &p, &len) != DPL_SUCCESS)
+            return DPL_FAILURE;
           is_first_param = 0;
         } else
-          DPL_APPEND_STR("&");
+          if (dpl_append_str("&", &p, &len) != DPL_SUCCESS)
+            return DPL_FAILURE;
 
-        DPL_APPEND_STR(param->key);
-        DPL_APPEND_STR("=");
-        DPL_APPEND_STR(dpl_sbuf_get_str(param->val->string));
+        if (dpl_append_str(param->key, &p, &len) != DPL_SUCCESS
+          || dpl_append_str("=", &p, &len) != DPL_SUCCESS
+          || dpl_append_str(dpl_sbuf_get_str(param->val->string), &p, &len) != DPL_SUCCESS)
+           return DPL_FAILURE;
       }
 
       param = param->prev;

--- a/libdroplet/src/backend/s3/reqbuilder.c
+++ b/libdroplet/src/backend/s3/reqbuilder.c
@@ -80,7 +80,8 @@ add_condition_to_headers(const dpl_condition_one_t *condition,
       char date_str[128];
       struct tm tm_buf;
 
-      ret = strftime(date_str, sizeof (date_str), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&condition->time, &tm_buf));
+      ret = dpl_strftime_c(date_str, sizeof (date_str), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&condition->time, &tm_buf));
+
       if (0 == ret)
         return DPL_FAILURE;
 
@@ -175,7 +176,8 @@ add_date_to_headers(dpl_dict_t *headers)
 
   (void) time(&t);
 
-  ret = strftime(date_str, sizeof (date_str), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&t, &tm_buf));
+  ret = dpl_strftime_c(date_str, sizeof (date_str), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&t, &tm_buf));
+
   if (ret == 0)
     return DPL_FAILURE;
   else

--- a/libdroplet/src/conn.c
+++ b/libdroplet/src/conn.c
@@ -527,14 +527,23 @@ dpl_conn_open_host(dpl_ctx_t *ctx, int af,
   dpl_conn_t            *conn = NULL;
   char                  *nstr;
 
-  ret2 = dpl_gethostbyname2_r(host, af, &hret, hbuf, sizeof (hbuf), &hresult, &herr);
+  if (ctx->proxy_server)
+    ret2 = dpl_gethostbyname2_r(ctx->proxy_server, af, &hret, hbuf, sizeof (hbuf), &hresult, &herr);
+  else
+    ret2 = dpl_gethostbyname2_r(host, af, &hret, hbuf, sizeof (hbuf), &hresult, &herr);
   if (0 != ret2 || hresult == NULL) {
     DPL_LOG(ctx, DPL_ERROR, "Failed to lookup hostname \"%s\": %s",
             host, hstrerror(herr));
     goto bad;
   }
 
-  port = atoi(portstr);
+  if (ctx->proxy_server && ctx->proxy_port)
+    port = atoi(ctx->proxy_port);
+  else if (ctx->proxy_server)
+    port = 8080;
+  else
+    port = atoi(portstr);
+
   conn = conn_open(ctx, hresult, port);
   if (NULL == conn) {
     DPL_TRACE(ctx, DPL_TRACE_ERR, "connect failed");

--- a/libdroplet/src/converters.c
+++ b/libdroplet/src/converters.c
@@ -149,7 +149,7 @@ dpl_canned_acl(char *str)
     return DPL_CANNED_ACL_PUBLIC_READ;
   else if (!strcasecmp(str, "public-read-write"))
     return DPL_CANNED_ACL_PUBLIC_READ_WRITE;
-  else if (!strcasecmp(str, "autenticated-read"))
+  else if (!strcasecmp(str, "authenticated-read"))
     return DPL_CANNED_ACL_AUTHENTICATED_READ;
   else if (!strcasecmp(str, "bucket-owner-read"))
     return DPL_CANNED_ACL_BUCKET_OWNER_READ;

--- a/libdroplet/src/droplet.c
+++ b/libdroplet/src/droplet.c
@@ -35,13 +35,6 @@
 
 /** @file */
 
-static char     *randbuf = 
-  "this isn't a very good way to seed the PRNG but will suffice"
-  "this isn't a very good way to seed the PRNG but will suffice"
-  "this isn't a very good way to seed the PRNG but will suffice"
-  "this isn't a very good way to seed the PRNG but will suffice"
-  "this isn't a very good way to seed the PRNG but will suffice";
-
 int dpl_header_size;
 
 const char *
@@ -124,7 +117,6 @@ dpl_init()
   SSL_load_error_strings();
   ERR_load_crypto_strings();
 
-  /* RAND_seed(randbuf, strlen(randbuf)); */
   int ret = RAND_status();
   if (0 == ret) {
     DPL_LOG(NULL, DPL_WARNING, "PRNG not properly seeded, seeding it...");

--- a/libdroplet/src/httprequest.c
+++ b/libdroplet/src/httprequest.c
@@ -150,7 +150,8 @@ dpl_add_condition_to_headers(const dpl_condition_t *cond,
           char date_str[128];
           struct tm tm_buf;
           
-          ret = strftime(date_str, sizeof (date_str), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&condition->time, &tm_buf));
+          ret = dpl_strftime_c(date_str, sizeof (date_str), "%a, %d %b %Y %H:%M:%S GMT", gmtime_r(&condition->time, &tm_buf));
+
           if (0 == ret)
             return DPL_FAILURE;
           

--- a/libdroplet/src/httprequest.c
+++ b/libdroplet/src/httprequest.c
@@ -300,6 +300,29 @@ dpl_req_gen_http_request(dpl_ctx_t *ctx,
 
   DPL_APPEND_STR(" ");
 
+  // See if we are using a proxy server then we need to use an absoluteURI.
+  if (ctx->proxy_server)
+    {
+      char *host_header;
+
+      if (ctx->use_https)
+        {
+            ret = DPL_FAILURE;
+            goto end;
+        }
+
+      // Lookup the Host header.
+      host_header = dpl_dict_get_value(headers, "Host");
+      if (NULL == host_header)
+        {
+            ret = DPL_FAILURE;
+            goto end;
+        }
+
+      DPL_APPEND_STR("http://");
+      DPL_APPEND_STR(host_header);
+    }
+
   if (resource_ue != NULL)
     DPL_APPEND_STR(resource_ue);
 

--- a/libdroplet/src/httprequest.c
+++ b/libdroplet/src/httprequest.c
@@ -70,36 +70,41 @@ dpl_add_range_to_headers_internal(const dpl_range_t *range,
 {
   int ret;
   char buf[1024];
-  int len = sizeof (buf);
+  size_t len = sizeof (buf);
   char *p;
   int first = 1;
   char str[128];
 
   p = buf;
 
-  DPL_APPEND_STR("bytes=");
+  if (dpl_append_str("bytes=", &p, &len) != DPL_SUCCESS)
+    return DPL_FAILURE;
 
   if (1 == first)
     first = 0;
   else
-    DPL_APPEND_STR(",");
+    if (dpl_append_str(",", &p, &len) != DPL_SUCCESS)
+      return DPL_FAILURE;
   
   if (DPL_UNDEF == range->start && DPL_UNDEF == range->end)
     return DPL_EINVAL;
   else if (DPL_UNDEF == range->start)
     {
       snprintf(str, sizeof (str), "-%lu", range->end);
-      DPL_APPEND_STR(str);
+      if (dpl_append_str(str, &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
     }
   else if (DPL_UNDEF == range->end)
     {
       snprintf(str, sizeof (str), "%lu-", range->start);
-      DPL_APPEND_STR(str);
+      if (dpl_append_str(str, &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
     }
   else
     {
       snprintf(str, sizeof (str), "%lu-%lu", range->start, range->end);
-      DPL_APPEND_STR(str);
+      if (dpl_append_str(str, &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
     }
 
   DPL_APPEND_CHAR(0);
@@ -252,7 +257,7 @@ dpl_req_gen_http_request(dpl_ctx_t *ctx,
                          const dpl_dict_t *headers,
                          const dpl_dict_t *query_params,
                          char *buf,
-                         int len,
+                         size_t len,
                          unsigned int *lenp)
 {
   int ret;
@@ -296,10 +301,13 @@ dpl_req_gen_http_request(dpl_ctx_t *ctx,
   }
       
   //method
-  DPL_APPEND_STR(method);
-
-  DPL_APPEND_STR(" ");
-
+  if (dpl_append_str(method, &p, &len) != DPL_SUCCESS ||
+    dpl_append_str(" ", &p, &len) != DPL_SUCCESS)
+    {
+       ret = DPL_FAILURE;
+       goto end;
+    }
+ 
   // See if we are using a proxy server then we need to use an absoluteURI.
   if (ctx->proxy_server)
     {
@@ -319,19 +327,35 @@ dpl_req_gen_http_request(dpl_ctx_t *ctx,
             goto end;
         }
 
-      DPL_APPEND_STR("http://");
-      DPL_APPEND_STR(host_header);
+      if (dpl_append_str("http://", &p, &len) != DPL_SUCCESS ||
+        dpl_append_str(host_header, &p, &len) != DPL_SUCCESS)
+        {
+           ret = DPL_FAILURE;
+           goto end;
+        }
     }
 
   if (resource_ue != NULL)
-    DPL_APPEND_STR(resource_ue);
+    if (dpl_append_str(resource_ue, &p, &len) != DPL_SUCCESS)
+      {
+         ret = DPL_FAILURE;
+         goto end;
+      }
 
   //subresource and query params
   if (NULL != req->subresource || NULL != query_params)
-    DPL_APPEND_STR("?");
+    if (dpl_append_str("?", &p, &len) != DPL_SUCCESS)
+      {
+         ret = DPL_FAILURE;
+         goto end;
+      }
 
   if (NULL != req->subresource)
-    DPL_APPEND_STR(req->subresource);
+    if (dpl_append_str(req->subresource, &p, &len) != DPL_SUCCESS)
+      {
+         ret = DPL_FAILURE;
+         goto end;
+      }
 
   if (NULL != query_params)
     {
@@ -347,21 +371,36 @@ dpl_req_gen_http_request(dpl_ctx_t *ctx,
           for (var = query_params->buckets[bucket];var;var = var->prev)
             {
               if (amp)
-                DPL_APPEND_STR("&");
-              DPL_APPEND_STR(var->key);
-              DPL_APPEND_STR("=");
+                if (dpl_append_str("&", &p, &len) != DPL_SUCCESS)
+                  {
+                     ret = DPL_FAILURE;
+                     goto end;
+                  }
+              if (dpl_append_str(var->key, &p, &len) != DPL_SUCCESS ||
+                dpl_append_str("=", &p, &len) != DPL_SUCCESS)
+                {
+                   ret = DPL_FAILURE;
+                   goto end;
+                }
               assert(var->val->type == DPL_VALUE_STRING);
-              DPL_APPEND_STR(dpl_sbuf_get_str(var->val->string));
+              if (dpl_append_str(dpl_sbuf_get_str(var->val->string), &p, &len) != DPL_SUCCESS)
+                {
+                   ret = DPL_FAILURE;
+                   goto end;
+                }
               amp = 1;
             }
         }
     }
 
-  DPL_APPEND_STR(" ");
-
   //version
-  DPL_APPEND_STR("HTTP/1.1");
-  DPL_APPEND_STR("\r\n");
+  if (dpl_append_str(" ", &p, &len) != DPL_SUCCESS ||
+    dpl_append_str("HTTP/1.1", &p, &len) != DPL_SUCCESS ||
+    dpl_append_str("\r\n", &p, &len) != DPL_SUCCESS)
+    {
+      ret = DPL_FAILURE;
+      goto end;
+    }
 
   //headers
   if (NULL != headers)
@@ -377,10 +416,14 @@ dpl_req_gen_http_request(dpl_ctx_t *ctx,
               DPL_TRACE(req->ctx, DPL_TRACE_REQ, "header='%s' value='%s'",
 			var->key, dpl_sbuf_get_str(var->val->string));
 
-              DPL_APPEND_STR(var->key);
-              DPL_APPEND_STR(": ");
-              DPL_APPEND_STR(dpl_sbuf_get_str(var->val->string));
-              DPL_APPEND_STR("\r\n");
+              if (dpl_append_str(var->key, &p, &len) != DPL_SUCCESS ||
+                dpl_append_str(": ", &p, &len) != DPL_SUCCESS ||
+                dpl_append_str(dpl_sbuf_get_str(var->val->string), &p, &len) != DPL_SUCCESS ||
+                dpl_append_str("\r\n", &p, &len) != DPL_SUCCESS)
+                {
+                  ret = DPL_FAILURE;
+                  goto end;
+                }
             }
         }
     }
@@ -396,6 +439,5 @@ dpl_req_gen_http_request(dpl_ctx_t *ctx,
   
   if (NULL != resource_ue)
     free(resource_ue);
-
   return ret;
 }

--- a/libdroplet/src/profile.c
+++ b/libdroplet/src/profile.c
@@ -672,6 +672,7 @@ dpl_profile_default(dpl_ctx_t *ctx)
   ctx->keep_alive = 1;
   ctx->url_encoding = 1;
   ctx->preserve_root_path = 0;
+  ctx->empty_folder_emulation = 1;
   ctx->max_redirects = DPL_DEFAULT_MAX_REDIRECTS;
   ctx->enterprise_number = DPL_DEFAULT_ENTERPRISE_NUMBER;
   ctx->base_path = strdup(DPL_DEFAULT_BASE_PATH);

--- a/libdroplet/src/profile.c
+++ b/libdroplet/src/profile.c
@@ -465,6 +465,20 @@ conf_cb_func(void *cb_arg,
           return -1;
         }
     }
+  else if (!strcmp(var, "proxy_server"))
+    {
+      free(ctx->proxy_server);
+      ctx->proxy_server = strdup(value);
+      if (NULL == ctx->proxy_server)
+        return -1;
+    }
+  else if (!strcmp(var, "proxy_port"))
+    {
+      free(ctx->proxy_port);
+      ctx->proxy_port = strdup(value);
+      if (NULL == ctx->proxy_port)
+        return -1;
+    }
   else if (!strcmp(var, "pricing"))
     {
       free(ctx->pricing);
@@ -1130,6 +1144,10 @@ dpl_profile_free(dpl_ctx_t *ctx)
     free(ctx->pricing);
   if (NULL != ctx->encrypt_key)
     free(ctx->encrypt_key);
+  if (NULL == ctx->proxy_server)
+    free(ctx->proxy_server);
+  if (NULL == ctx->proxy_port)
+    free(ctx->proxy_port);
   if (NULL != ctx->pricing_dir)
     free(ctx->pricing_dir);
 

--- a/libdroplet/src/req.c
+++ b/libdroplet/src/req.c
@@ -99,7 +99,10 @@ dpl_req_new(dpl_ctx_t *ctx)
     goto bad;
 
   //virtual hosting is prefered since it "disperses" connections
-  req->behavior_flags = DPL_BEHAVIOR_KEEP_ALIVE|DPL_BEHAVIOR_VIRTUAL_HOSTING;
+  if (ctx->default_behavior_flags)
+    req->behavior_flags = ctx->default_behavior_flags;
+  else
+    req->behavior_flags = DPL_BEHAVIOR_KEEP_ALIVE | DPL_BEHAVIOR_VIRTUAL_HOSTING;
 
   return req;
 

--- a/libdroplet/src/utils.c
+++ b/libdroplet/src/utils.c
@@ -1079,21 +1079,25 @@ dpl_log(dpl_ctx_t *ctx,
   case DPL_ERROR: level_name = "error"; break;
   }
   if (level_name) {
-    DPL_APPEND_STR(level_name);
-    DPL_APPEND_STR(": ");
+    if (dpl_append_str(level_name, &p, &len) != DPL_SUCCESS
+      || dpl_append_str(": ", &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
   }
 
   if (file) {
-    DPL_APPEND_STR(file);
-    DPL_APPEND_CHAR(':');
+    if (dpl_append_str(file, &p, &len) != DPL_SUCCESS
+      || dpl_append_str(":", &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
     snprintf(linebuf, sizeof(linebuf), "%d", lineno);
-    DPL_APPEND_STR(linebuf);
-    DPL_APPEND_STR(": ");
+    if (dpl_append_str(linebuf, &p, &len) != DPL_SUCCESS
+      || dpl_append_str(": ", &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
   }
 
   if (func) {
-    DPL_APPEND_STR(func);
-    DPL_APPEND_STR(": ");
+    if (dpl_append_str(func, &p, &len) != DPL_SUCCESS
+      || dpl_append_str(": ", &p, &len) != DPL_SUCCESS)
+        return DPL_FAILURE;
   }
 
   va_start(args, fmt);
@@ -1288,4 +1292,20 @@ dpl_get_xattrs(char *path, dpl_dict_t *dict, char *prefix, int do_64encode)
     }
 
   return ret;
+}
+
+dpl_status_t
+dpl_append_str(const char *str_to_add, char **buff, size_t *size_buff)
+{
+  size_t  len_str_to_add;
+
+  if (str_to_add == NULL)
+    return DPL_FAILURE;
+  len_str_to_add = strlen(str_to_add);
+  if (*size_buff < len_str_to_add)
+    return DPL_FAILURE;
+  memcpy(*buff, str_to_add, len_str_to_add);
+  *buff += len_str_to_add;
+  *size_buff -= len_str_to_add;
+  return DPL_SUCCESS;
 }

--- a/libdroplet/src/utils.c
+++ b/libdroplet/src/utils.c
@@ -35,6 +35,7 @@
 #include <linux/xattr.h>
 #include <attr/xattr.h>
 #include <errno.h>
+#include <locale.h>
 
 /** @file */
 
@@ -1309,3 +1310,35 @@ dpl_append_str(const char *str_to_add, char **buff, size_t *size_buff)
   *size_buff -= len_str_to_add;
   return DPL_SUCCESS;
 }
+
+/**/
+
+/**
+ * format time string using locale definition C. Parameters are the same as in strftime function.
+ *
+ * @param str pointer to the character array
+ * @param maxsize size of str
+ * @param format format specification
+ * @param timeptr time strucutre
+ *
+ * @return number of characters placed in str (without null)
+ */
+
+size_t
+dpl_strftime_c(char *str, size_t maxsize, const char *format,  const struct tm *timeptr)
+{ 
+  size_t ret=0;
+  char locale_saved[128];
+  char *locale_current=NULL;
+  locale_current=setlocale(LC_TIME,0);
+  if(NULL != locale_current)
+    strncpy(locale_saved,locale_current,128);
+  setlocale(LC_TIME, "C");
+
+  ret = strftime(str, maxsize, format, timeptr);
+
+  if(NULL != locale_current)
+    setlocale(LC_TIME,locale_saved);
+  return ret;
+}
+

--- a/utests/tests/profile_utest.c
+++ b/utests/tests/profile_utest.c
@@ -268,7 +268,7 @@ START_TEST(ctx_new_params_test)
   dpl_assert_str_eq(ctx->droplet_dir, dropdir);
   dpl_assert_str_eq(ctx->profile_name, "default");
   dpl_assert_str_eq(ctx->base_path, "/polaroid");
-  dpl_assert_int_eq(ctx->use_https, 1);
+  dpl_assert_bit_eq(ctx->use_https, 1);
   dpl_assert_int_eq(ctx->blacklist_expiretime, 42);
   dpl_assert_int_eq(ctx->header_size, 12345);
   dpl_assert_str_eq(ctx->access_key, "letterpress");
@@ -282,7 +282,7 @@ START_TEST(ctx_new_params_test)
   dpl_assert_int_eq(ctx->read_buf_size, 8765);
   dpl_assert_str_eq(ctx->encrypt_key, "distillery");
   dpl_assert_str_eq(ctx->backend->name, "swift");
-  dpl_assert_int_eq(ctx->encode_slashes, 1);
+  dpl_assert_bit_eq(ctx->encode_slashes, 1);
 
   dpl_ctx_free(ctx);
   free(dropdir);

--- a/utests/utest_main.h
+++ b/utests/utest_main.h
@@ -28,6 +28,22 @@ extern Suite    *s3_auth_v4_suite(void);
  * be NULL.
  */
 
+/* Bit comparison macros with improved output compared to fail_unless(). */
+/* O may be any comparison operator. */
+#define _dpl_assert_bit(X, O, Y) \
+    do { \
+	struct x { \
+	    int a:1; \
+	}; \
+	struct x _x; \
+	_x.a=(X); \
+	struct x _y; \
+	_y.a=(Y); \
+	ck_assert_msg(_x.a O _y.a, "Assertion '"#X#O#Y"' failed: "#X"==%d, "#Y"==%d", _x.a, _y.a); \
+    } while(0)
+#define dpl_assert_bit_eq(X, Y) _dpl_assert_bit(X, ==, Y)
+#define dpl_assert_bit_ne(X, Y) _dpl_assert_bit(X, !=, Y)
+
 /* Integer comparison macros with improved output compared to fail_unless(). */
 /* O may be any comparison operator. */
 #define _dpl_assert_int(X, O, Y) \


### PR DESCRIPTION
Make S3 request header compliant with RFC 7231.

This fix resolve problem with one sort of not working backups on S3.
This problem affect all systems with default locale set to non-english.

Changes in this pull:
- locale is changed temporally to "C" while call strftime_c by wrapper function dpl_strftime_c
- this bug affected only one strftime call for clear code all calls of strftime has been replaced by dpl_strftime_c


